### PR TITLE
Hide invited speakers behind a TBD placeholder

### DIFF
--- a/index.html
+++ b/index.html
@@ -159,6 +159,13 @@
           <h2>Invited Speakers</h2>
         </div>
         <div class="row justify-content-center">
+          <div class="col-lg-10 text-center">
+            <p style="font-size: 24px;">TBD</p>
+          </div>
+        </div>
+
+        <!-- Speakers hidden for now; un-hide when the lineup is confirmed
+        <div class="row justify-content-center">
           <div class="col-lg-3 col-md-4 col-xs-6">
             <div class="speaker">
               <img src="img/speakers/KaiWeiChang.jpg" alt="Kai-Wei Chang" class="img-fluid">
@@ -259,6 +266,7 @@
             </div>
           </div>
         </div>
+        -->
       </div>
     </section>
 


### PR DESCRIPTION
Hides the eight speaker cards behind a TBD placeholder (cards preserved in the source, commented out) until the lineup is confirmed. Follow-up to #6.