### PR TITLE
Refine 2026 edition: header, Rising Star Award button, organizer groups, CFP

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -851,6 +851,25 @@ body.mobile-nav-active #mobile-nav-toggle {
   color: #f82249;
 }
 
+/* Organizer group labels (merged-workshop tracks) */
+#organizers .org-group {
+  display: inline-block;
+  padding: 9px 32px;
+  border-radius: 50px;
+  font-family: "Raleway", sans-serif;
+  font-weight: 700;
+  font-size: 21px;
+  letter-spacing: 1px;
+  color: #fff;
+  background: #56539c;
+  box-shadow: 0 6px 18px rgba(49, 47, 98, 0.25);
+  margin: 0 0 38px;
+}
+
+#organizers .org-group.cotma {
+  margin-top: 25px;
+}
+
 #speakers-details {
   padding: 60px 0;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -645,6 +645,27 @@ body.mobile-nav-active #mobile-nav-toggle {
   color: #fff;
 }
 
+#award_app .about-btn {
+  font-family: "Raleway", sans-serif;
+  font-weight: 500;
+  font-size: 20px;
+  letter-spacing: 2px;
+  display: inline-block;
+  padding: 10px 28px;
+  border-radius: 50px;
+  transition: 0.5s;
+  line-height: 2;
+  margin: 10px 10px 28px;
+  color: #f82249;
+  background: transparent;
+  border: 3px solid #f82249;
+}
+
+#award_app .about-btn:hover {
+  background: #f82249;
+  color: #fff;
+}
+
 @-webkit-keyframes pulsate-btn {
   0% {
     -webkit-transform: scale(0.6, 0.6);

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <!-- Uncomment below if you prefer to use a text logo -->
         <!-- <h1><a href="#main">C<span>o</span>nf</a></h1>-->
         <!-- <a href="#intro" class="scrollto"><img src="img/logo.png" alt="" title=""></a> -->
-        <a href="#intro" class="scrollto"><p style="font-size:30px;color:white">AdvML-Frontiers &times; CoTMA @ COLM'26</p></a>
+        <a href="#intro" class="scrollto"><p style="font-size:24px;color:white">AdvML-Frontiers &times; CoTMA @ COLM'26</p></a>
       </div>
 
       <nav id="nav-menu-container" class="navbar navbar-default navbar-fixed-top">
@@ -295,12 +295,12 @@
       <div class="container wow fadeInUp">
         <div class="section-header">
           <br><br>
-          <h2>AdvML Rising Star Award &mdash; Call for Application</h2>
+          <h2><a href="https://sites.google.com/view/advml/advml-rising-star-award" target="_blank" rel="noopener noreferrer">AdvML Rising Star Award</a> &mdash; Call for Application</h2>
         </div>
 
       <h3 class="mb-3 text-left"><b>Application Instructions</b></h3>
 
-        <p style="font-size: 20px;"><b>Eligibility and Requirements:</b> Senior PhD students enrolled in a PhD program before December 2022, or researchers holding postdoctoral positions who obtained their PhD degree after April 2023.</p>
+        <p style="font-size: 20px;"><b>Eligibility and Requirements:</b> Senior PhD students enrolled in a PhD program before December 2022 or researchers holding postdoctoral positions (including faculty positions) who obtained PhD degree after April 2023.</p>
 
         <b style="font-size: 20px;">Applicants are required to submit the following materials:
         <ul class="" style="font-size: 20px;">
@@ -320,10 +320,6 @@
           <tr>
             <td style="vertical-align: top;"><b style="font-size: 18px;">Recommendation letters</b></td>
             <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">Jul 31, 2026</b></td>
-          </tr>
-          <tr>
-            <td style="vertical-align: top;"><b style="font-size: 18px;">Winners announced</b></td>
-            <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">August 2026</b></td>
           </tr>
         </table>
       </div>

--- a/index.html
+++ b/index.html
@@ -295,8 +295,14 @@
       <div class="container wow fadeInUp">
         <div class="section-header">
           <br><br>
-          <h2><a href="https://sites.google.com/view/advml/advml-rising-star-award" target="_blank" rel="noopener noreferrer">AdvML Rising Star Award</a> &mdash; Call for Application</h2>
+          <h2>AdvML Rising Star Award &mdash; Call for Application</h2>
         </div>
+
+      <div class="row">
+        <div class="col-lg-12 text-center">
+          <a href="https://sites.google.com/view/advml/advml-rising-star-award" class="about-btn scrollto" target="_blank" rel="noopener noreferrer"><b>2026 AdvML Rising Star Award</b></a>
+        </div>
+      </div>
 
       <h3 class="mb-3 text-left"><b>Application Instructions</b></h3>
 
@@ -309,7 +315,7 @@
           <li class="text-left">A 5-minute video recording summarizing your research</li>
           <li class="text-left">Two letters of recommendation (submission form to be announced)</li>
         </ul>
-        The awardee must attend the AdvML-Frontiers &times; CoTMA workshop at COLM 2026 and give a presentation in person. The application form will be announced soon.</b><br><br>
+        The awardee must attend the AdvML-Frontiers &times; CoTMA workshop @ COLM 2026 and give a presentation in person. The application form will be announced soon.</b><br><br>
 
         <p style="font-size: 24px;">Important dates</p>
         <table>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <!-- Uncomment below if you prefer to use a text logo -->
         <!-- <h1><a href="#main">C<span>o</span>nf</a></h1>-->
         <!-- <a href="#intro" class="scrollto"><img src="img/logo.png" alt="" title=""></a> -->
-        <a href="#intro" class="scrollto"><p style="font-size:24px;color:white">AdvML-Frontiers &times; CoTMA @ COLM'26</p></a>
+        <a href="#intro" class="scrollto"><p style="font-size:24px;color:white;position:relative;top:5px">AdvML-Frontiers &times; CoTMA @ COLM'26</p></a>
       </div>
 
       <nav id="nav-menu-container" class="navbar navbar-default navbar-fixed-top">

--- a/index.html
+++ b/index.html
@@ -501,7 +501,6 @@
                 <div class="social">
                   <a href="https://scholar.google.de/citations?user=LrYcIxYAAAAJ&hl=en"><i class="fa fa-globe" style="font-size:28px"></i></a>
                   <a href="https://x.com/KathrinGrosse" target="_blank" rel="noopener noreferrer"><i class="fa fa-twitter" style="font-size:28px"></i></a>
-                  <a href="https://scholar.google.de/citations?user=LrYcIxYAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -551,6 +550,7 @@
                 <p>Amazon AGI</p>
                 <div class="social">
                   <a href="https://www.amazon.science/author/abhinav-mohanty"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=XbLh3_YAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -559,10 +559,11 @@
             <div class="speaker">
               <img src="img/organizers/TongWang.jpg" alt="Tong Wang" class="img-fluid">
               <div class="details">
-                <h3><a href="#">Tong Wang</a></h3>
+                <h3><a href="https://tongwang-umb.github.io/">Tong Wang</a></h3>
                 <p>Amazon AGI</p>
                 <div class="social">
-                  <a href="#"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://tongwang-umb.github.io/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=71YhaA8AAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -575,6 +576,7 @@
                 <p>University of Southern California</p>
                 <div class="social">
                   <a href="https://swabhs.com/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=3uTVQt0AAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -587,6 +589,7 @@
                 <p>Meta</p>
                 <div class="social">
                   <a href="https://ninarehm.github.io/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=3SfPdIQAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -602,6 +605,7 @@
                 <p>Meta</p>
                 <div class="social">
                   <a href="https://anilkramakrishna.github.io/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=KNu_OpsAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -614,6 +618,7 @@
                 <p>KAIST AI</p>
                 <div class="social">
                   <a href="https://yeonsungjung.github.io/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=RP0cr2wAAAAJ&hl=ko"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -626,6 +631,7 @@
                 <p>UCLA</p>
                 <div class="social">
                   <a href="https://homahm.github.io/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=Zb68N-kAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>
@@ -634,10 +640,11 @@
             <div class="speaker">
               <img src="img/organizers/ChristosChristodoulopoulos.jpg" alt="Christos Christodoulopoulos" class="img-fluid">
               <div class="details">
-                <h3 style="font-size: 15px;"><a href="http://christos-c.com/">Christos Christodoulopoulos</a></h3>
+                <h3 style="font-size: 15px;"><a href="https://christos-c.com/">Christos Christodoulopoulos</a></h3>
                 <p>UK ICO</p>
                 <div class="social">
-                  <a href="http://christos-c.com/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://christos-c.com/"><i class="fa fa-globe" style="font-size:28px"></i></a>
+                  <a href="https://scholar.google.com/citations?user=oZORQtwAAAAJ&hl=en"><i class="fa fa-google" style="font-size:28px"></i></a>
                 </div>
               </div>
             </div>

--- a/index.html
+++ b/index.html
@@ -413,6 +413,12 @@
         </div>
 
         <div class="row justify-content-center">
+          <div class="col-lg-12 text-center">
+            <h3 class="org-group advml">AdvML-Frontiers Organizers</h3>
+          </div>
+        </div>
+
+        <div class="row justify-content-center">
           <div class="col-lg-3 col-md-4 col-xs-6">
             <div class="speaker">
               <img src="img/organizers/SLiu.jpeg" alt="Sijia Liu" class="img-fluid img-pos-bottom">
@@ -527,6 +533,12 @@
                 </div>
               </div>
             </div>
+          </div>
+        </div>
+
+        <div class="row justify-content-center">
+          <div class="col-lg-12 text-center">
+            <h3 class="org-group cotma">CoTMA Organizers</h3>
           </div>
         </div>
 

--- a/index.html
+++ b/index.html
@@ -49,7 +49,7 @@
         <!-- Uncomment below if you prefer to use a text logo -->
         <!-- <h1><a href="#main">C<span>o</span>nf</a></h1>-->
         <!-- <a href="#intro" class="scrollto"><img src="img/logo.png" alt="" title=""></a> -->
-        <a href="#intro" class="scrollto"><p style="font-size:30px;color:white">AdvML-Frontiers &times; CoTMA'26</p></a>
+        <a href="#intro" class="scrollto"><p style="font-size:30px;color:white">AdvML-Frontiers &times; CoTMA @ COLM'26</p></a>
       </div>
 
       <nav id="nav-menu-container" class="navbar navbar-default navbar-fixed-top">
@@ -102,7 +102,7 @@
   ============================-->
   <section id="intro">
     <div class="intro-container wow fadeIn">
-	  <h1 class="mb-4 pb-0">AdvML-Frontiers &times; CoTMA<br></h1> 
+	  <h1 class="mb-4 pb-0">AdvML-Frontiers &times; CoTMA:<br></h1>
     <h1>From Model Security to Compositional Threats in Multi-Agent AI Systems</h1>
 	  <h1 class="mb-4 pb-0">@ <a href="https://colmweb.org/" target="_blank" rel="noopener noreferrer">COLM 2026</a></h1>
       <p class="mb-4 pb-0" style="font-size:36px" color="white"> October 9, 2026 </p>

--- a/index.html
+++ b/index.html
@@ -344,7 +344,7 @@
         <h4><b>Submission Format</b></h4>
         <p style="font-size: 20px; text-align: justify">We invite paper submissions of up to <b>6 pages</b> (excluding references and supplementary material).</p>
 
-        <p style="font-size: 20px; text-align: justify">Please ensure that all submissions conform to the <a href="resources/advml-frontiers2026-template.zip">AdvML-Frontiers &times; CoTMA format template</a> and submit via <a href="#">OpenReview</a> (submission link to be announced). Accepted papers are <b>non-archival</b> and <b>non-inproceedings</b>. Concurrent submissions are allowed, but it is the responsibility of the authors to verify compliance with other venues' policies. Based on the program committee's recommendation, accepted papers will be allocated either a spotlight talk or a poster presentation.</p>
+        <p style="font-size: 20px; text-align: justify">Please ensure that all submissions conform to the COLM template and submit via <a href="#">OpenReview</a> (submission link to be announced). Accepted papers are <b>non-archival</b> (which will not appear in formal conference proceedings). Concurrent submissions are allowed, but it is the responsibility of the authors to verify compliance with other venues' policies. Accepted papers will be allocated either a spotlight talk or a poster presentation.</p>
 
         <h4><b>Important Dates</b></h4>
         <style>


### PR DESCRIPTION
Follow-up polish to the **AdvML-Frontiers × CoTMA @ COLM 2026** edition (builds on the already-merged #6/#7/#8). All changes are in `index.html` and `css/style.css`.

## Header
- Brand title → **AdvML-Frontiers × CoTMA @ COLM'26**; hero title gains a colon so the tagline reads as a subtitle.
- Shrink the brand font (30px → 24px) and nudge it down to align with the nav menu.

## Rising Star Award
- Link the award name to the official AdvML Rising Star Award page.
- Match the eligibility wording to the official page (incl. faculty positions); remove the "Winners announced" row.
- Replace the heading link with a centered red outlined-pill button **"2026 AdvML Rising Star Award."**
- Use "@ COLM 2026" wording for the awardee requirement.

## Organizers
- Split the merged-workshop roster into **AdvML-Frontiers Organizers** and **CoTMA Organizers**, shown as navy pill subheadings.
- Add Google Scholar links to the 8 CoTMA organizers; fix Tong Wang's broken website link; upgrade Christos to https; drop Kathrin's duplicate Scholar icon.
- All 16 organizer photos and links audited and confirmed correct (incl. same-name checks).

## Call for Papers
- Reference the **COLM template**; clarify that accepted papers are non-archival (won't appear in formal proceedings); drop the "program committee recommendation" clause.

## Preview
https://advml-frontiers-2026.vercel.app
