### PR TITLE
Rework Rising Star Award application instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ CLAUDE*.md
 .mcp.json
 ref/
 .vercel
+work_logs/

--- a/css/style.css
+++ b/css/style.css
@@ -666,6 +666,96 @@ body.mobile-nav-active #mobile-nav-toggle {
   color: #fff;
 }
 
+/*--- AdvML Rising Star: refined application instructions ---*/
+#award_app .award-section-title {
+  position: relative;
+  display: inline-block;
+  font-weight: 700;
+  padding-bottom: 0.45rem;
+  margin-bottom: 1.5rem;
+}
+
+#award_app .award-section-title::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 56px;
+  height: 3px;
+  background: #f82249;
+  border-radius: 2px;
+}
+
+#award_app .award-steps {
+  list-style: none;
+  counter-reset: step;
+  padding-left: 0;
+  margin: 0 0 0.5rem;
+  max-width: 880px;
+  font-size: 18px;
+  line-height: 1.75;
+  color: #2f3138;
+}
+
+#award_app .award-steps > li {
+  counter-increment: step;
+  position: relative;
+  padding-left: 2rem;
+  margin-bottom: 1.15rem;
+}
+
+#award_app .award-steps > li::before {
+  content: counter(step) ".";
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 1.5rem;
+  font-weight: 700;
+  line-height: 1.75;
+  color: #0e1b4d;
+}
+
+#award_app .award-substeps {
+  list-style: none;
+  counter-reset: substep;
+  padding-left: 0;
+  margin: 0.7rem 0 0;
+}
+
+#award_app .award-substeps > li {
+  counter-increment: substep;
+  position: relative;
+  padding-left: 2.3rem;
+  margin-bottom: 0.55rem;
+}
+
+#award_app .award-substeps > li:last-child {
+  margin-bottom: 0;
+}
+
+#award_app .award-substeps > li::before {
+  content: "(" counter(substep, lower-alpha) ").";
+  position: absolute;
+  left: 0;
+  top: 0;
+  font-weight: 600;
+  color: #0e1b4d;
+}
+
+#award_app .award-steps a {
+  color: #f82249;
+  font-weight: 600;
+  text-decoration: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 3px;
+  text-decoration-color: rgba(248, 34, 73, 0.45);
+  transition: text-decoration-color 0.3s;
+}
+
+#award_app .award-steps a:hover {
+  text-decoration-color: #f82249;
+}
+
 @-webkit-keyframes pulsate-btn {
   0% {
     -webkit-transform: scale(0.6, 0.6);

--- a/index.html
+++ b/index.html
@@ -298,24 +298,22 @@
           <h2>AdvML Rising Star Award &mdash; Call for Application</h2>
         </div>
 
-      <div class="row">
-        <div class="col-lg-12 text-center">
-          <a href="https://sites.google.com/view/advml/advml-rising-star-award" class="about-btn scrollto" target="_blank" rel="noopener noreferrer"><b>2026 AdvML Rising Star Award</b></a>
-        </div>
-      </div>
+      <h3 class="award-section-title text-left">Application Instructions</h3>
 
-      <h3 class="mb-3 text-left"><b>Application Instructions</b></h3>
-
-        <p style="font-size: 20px;"><b>Eligibility and Requirements:</b> Senior PhD students enrolled in a PhD program before December 2022 or researchers holding postdoctoral positions (including faculty positions) who obtained PhD degree after April 2023.</p>
-
-        <b style="font-size: 20px;">Applicants are required to submit the following materials:
-        <ul class="" style="font-size: 20px;">
-          <li class="text-left">CV (including a list of publications)</li>
-          <li class="text-left">Research statement (up to 2 pages, single column, excluding references), including your research accomplishments and future research directions</li>
-          <li class="text-left">A 5-minute video recording summarizing your research</li>
-          <li class="text-left">Two letters of recommendation (submission form to be announced)</li>
-        </ul>
-        The awardee must attend the AdvML-Frontiers &times; CoTMA workshop @ COLM 2026 and give a presentation in person. The application form will be announced soon.</b><br><br>
+        <ol class="award-steps">
+          <li class="text-left"><b>Eligibility and Requirements:</b> Senior PhD students enrolled in a PhD program before December 2022 or researchers holding postdoctoral positions (including faculty positions) who obtained PhD degree after April 2023.</li>
+          <li class="text-left">Applicants are required to submit the following materials:
+            <ul class="award-substeps">
+              <li class="text-left">CV (including a list of publications).</li>
+              <li class="text-left">Research statement (up to 2 pages, single column, excluding references), including your research accomplishments and future research directions.</li>
+              <li class="text-left">A 5-minute video recording for your research summary.</li>
+              <li class="text-left">Two letters of recommendation uploaded to <a href="https://forms.gle/pKYAfKCTfJUStLrn8" target="_blank" rel="noopener noreferrer">this form</a> by the referees before July 31st, 2026 (AoE).</li>
+            </ul>
+          </li>
+          <li class="text-left">The awardee must attend the COLM AdvML-Frontiers &times; CoTMA Workshop and give a presentation in person.</li>
+          <li class="text-left">Submit the required materials (a),(b),(c) to <a href="https://forms.gle/wtc7wrB35NKbQMdF9" target="_blank" rel="noopener noreferrer">this form</a> by July 24th, 2026 (AoE).</li>
+        </ol>
+        <br>
 
         <p style="font-size: 24px;">Important dates</p>
         <table>
@@ -328,6 +326,12 @@
             <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">Jul 31, 2026</b></td>
           </tr>
         </table>
+        <br>
+      <div class="row">
+        <div class="col-lg-12 text-center">
+          <a href="https://sites.google.com/view/advml/advml-rising-star-award" class="about-btn scrollto" target="_blank" rel="noopener noreferrer"><b>2026 AdvML Rising Star Award</b></a>
+        </div>
+      </div>
       </div>
 
     </section>


### PR DESCRIPTION
Updates the AdvML Rising Star Award section:

- Restructure Application Instructions into a numbered 1-4 list with (a)-(d) sub-items
- Link the application-materials form and the recommendation-letters form
- Move the 2026 AdvML Rising Star Award button below the Important dates table
- Refine #award_app styling: navy counters, hanging indents, line-height, underlined links, section-title accent