### PR TITLE
Update workshop contact email to advml-frontiers-cotma26 list

### DIFF
--- a/index.html
+++ b/index.html
@@ -682,7 +682,7 @@
       </div>
 
       <h4><b>Contacts</b></h4>
-              <p style="font-size: 20px; text-align: justify">For website-related questions, please contact the Workshop Publicity Student Chair. For paper submission and logistics questions, please contact the organizing committee at <a href="mailto:advml_frontiers24@googlegroups.com">advml_frontiers24@googlegroups.com</a>.</p>
+              <p style="font-size: 20px; text-align: justify">For website-related questions, please contact the Workshop Publicity Student Chair. For paper submission and logistics questions, please contact the organizing committee at <a href="mailto:advml-frontiers-cotma26@googlegroups.com">advml-frontiers-cotma26@googlegroups.com</a>.</p>
 
     </div>
     </section>


### PR DESCRIPTION
Replace the stale 2024 mailing list with the 2026 AdvML-Frontiers × CoTMA list in the current edition's contact paragraph.