### PR TITLE
Link OpenReview submission portal

### DIFF
--- a/index.html
+++ b/index.html
@@ -348,7 +348,7 @@
         <h4><b>Submission Format</b></h4>
         <p style="font-size: 20px; text-align: justify">We invite paper submissions of up to <b>6 pages</b> (excluding references and supplementary material).</p>
 
-        <p style="font-size: 20px; text-align: justify">Please ensure that all submissions conform to the COLM template and submit via <a href="#">OpenReview</a> (submission link to be announced). Accepted papers are <b>non-archival</b> (which will not appear in formal conference proceedings). Concurrent submissions are allowed, but it is the responsibility of the authors to verify compliance with other venues' policies. Accepted papers will be allocated either a spotlight talk or a poster presentation.</p>
+        <p style="font-size: 20px; text-align: justify">Please ensure that all submissions conform to the COLM template and submit via <a href="https://openreview.net/group?id=colmweb.org/COLM/2026/Workshop/AdvML-Frontiers-CoTMA#tab-recent-activity" target="_blank" rel="noopener noreferrer">OpenReview</a>. Accepted papers are <b>non-archival</b> (which will not appear in formal conference proceedings). Concurrent submissions are allowed, but it is the responsibility of the authors to verify compliance with other venues' policies. Accepted papers will be allocated either a spotlight talk or a poster presentation.</p>
 
         <h4><b>Important Dates</b></h4>
         <style>


### PR DESCRIPTION
Wire the Call for Papers submission link to the workshop's OpenReview venue and drop the 'submission link to be announced' placeholder.

Preview: https://advml-frontiers-2026.vercel.app