### PR TITLE
Extend paper submission deadline to Jun 30, 2026 (AoE)

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
         <table>
           <tr>
             <td style="vertical-align: top;"><b style="font-size: 18px;">Submission deadline</b></td>
-            <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">Jun 23, 2026 (AoE)</b></td>
+            <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">Jun 30, 2026 (AoE)</b></td>
           </tr>
           <tr>
             <td style="vertical-align: top;"><b style="font-size: 18px;">Notification to authors</b></td>


### PR DESCRIPTION
Updates the Submission deadline in the Call for Papers → Important Dates table from Jun 23 to Jun 30, 2026 (AoE), per the organizers' decision to extend. No other dates changed.