### PR TITLE
Show original submission deadline struck through with extension note

### DIFF
--- a/index.html
+++ b/index.html
@@ -358,7 +358,7 @@
         <table>
           <tr>
             <td style="vertical-align: top;"><b style="font-size: 18px;">Submission deadline</b></td>
-            <td style="vertical-align: top;"><b style="font-size: 18px; color: gray">Jun 30, 2026 (AoE)</b></td>
+            <td style="vertical-align: top;"><b style="font-size: 18px; color: gray"><s>Jun 23, 2026 (AoE)</s> (Extended to Jun 30, 2026 AoE)</b></td>
           </tr>
           <tr>
             <td style="vertical-align: top;"><b style="font-size: 18px;">Notification to authors</b></td>


### PR DESCRIPTION
Per organizers' preference: instead of replacing the date, keep the original deadline struck through with the extension noted alongside — renders as 'Jun 23, 2026 (AoE) (Extended to Jun 30, 2026 AoE)'.