### PR TITLE
Add finalized 2026 workshop schedule

### DIFF
--- a/index.html
+++ b/index.html
@@ -278,10 +278,177 @@
         <div class="section-header">
           <h2>Schedule</h2>
         </div>
-        <div class="row justify-content-center">
-          <div class="col-lg-10 text-center">
-            <p style="font-size: 24px;">TBD</p>
-          </div>
+        <div role="tabpanel" class="col-lg-9 tab-pane fade show active" id="day-1">
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 8:30-8:40 </time></div>
+              <div class="col-md-10">
+                <h4>Opening Remarks</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 8:40-9:10 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/NicoleNichols.webp" alt="Nicole Nichols">
+                </div>
+                <h4>Invited Talk (AdvML)</h4>
+                <h5><b>Nicole Nichols</b></h5>
+                <p>Palo Alto Networks</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 9:10-9:40 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/SomeshJha.jpg" alt="Somesh Jha">
+                </div>
+                <h4>Invited Talk (AdvML)</h4>
+                <h5><b>Somesh Jha</b></h5>
+                <p>University of Wisconsin&ndash;Madison</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 9:40-9:55 </time></div>
+              <div class="col-md-10">
+                <h4>&#9749; Coffee Break</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 9:55-10:00 </time></div>
+              <div class="col-md-10">
+                <h4>AdvML Rising Star Award &amp; Best Paper Awards Announcement</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 10:00-10:40 </time></div>
+              <div class="col-md-10">
+                <h4>AdvML Rising Star Award Presentations</h4>
+                <p>(4 &times; 10 min)</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 10:40-11:10 </time></div>
+              <div class="col-md-10">
+                <h4>Invited Talk (CoTMA)</h4>
+                <h5><b>Evangelos Papalexakis</b></h5>
+                <p>University of California, Riverside</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 11:10-11:40 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/RahulGupta.png" alt="Rahul Gupta">
+                </div>
+                <h4>Invited Talk (CoTMA)</h4>
+                <h5><b>Rahul Gupta</b></h5>
+                <p>Amazon AGI</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 11:40-12:00 </time></div>
+              <div class="col-md-10">
+                <h4>Oral / Spotlight Paper Presentations I</h4>
+                <p>(2 &times; 10 min)</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 12:00-13:00 </time></div>
+              <div class="col-md-10">
+                <h4>&#127869; Lunch</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 13:00-13:40 </time></div>
+              <div class="col-md-10">
+                <h4>Poster Session 1</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 13:40-14:10 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/IliaShumailov.jpg" alt="Ilia Shumailov">
+                </div>
+                <h4>Invited Talk (AdvML)</h4>
+                <h5><b>Ilia Shumailov</b></h5>
+                <p>Meta</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 14:10-14:40 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/EugeneBagdasarian.jpg" alt="Eugene Bagdasarian">
+                </div>
+                <h4>Invited Talk (CoTMA)</h4>
+                <h5><b>Eugene Bagdasarian</b></h5>
+                <p>UMass Amherst &amp; Google</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 14:40-15:10 </time></div>
+              <div class="col-md-10">
+                <div class="speaker">
+                  <img src="img/speakers/MotahhareEslami.jpg" alt="Motahhare Eslami">
+                </div>
+                <h4>Invited Talk (AdvML)</h4>
+                <h5><b>Motahhare Eslami</b></h5>
+                <p>Carnegie Mellon University</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 15:10-15:30 </time></div>
+              <div class="col-md-10">
+                <h4>Oral / Spotlight Paper Presentations II</h4>
+                <p>(2 &times; 10 min)</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 15:30-16:15 </time></div>
+              <div class="col-md-10">
+                <h4>&#9749; Coffee Break + Poster Session 2</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 16:15-17:15 </time></div>
+              <div class="col-md-10">
+                <h4>Panel Discussion</h4>
+                <p>Evtimov, Beirami, Cameron, Baracaldo, Bagdasarian</p>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 17:15-17:25 </time></div>
+              <div class="col-md-10">
+                <h4>Best Paper Awards</h4>
+              </div>
+            </div>
+
+            <div class="row schedule-item">
+              <div class="col-md-2"><time><center>Time: <br> 17:25-17:30 </time></div>
+              <div class="col-md-10">
+                <h4>Closing Remarks</h4>
+              </div>
+            </div>
+
         </div>
       </div>
     </section>


### PR DESCRIPTION
Replaces the "TBD" placeholder in the Schedule section of `index.html` with the full finalized single-day program (19 rows), reusing last year's `schedule-item` layout.

Includes: opening remarks, invited talks (with speaker photos, names, and affiliations) tagged AdvML/CoTMA, AdvML Rising Star Award announcement + presentations, oral/spotlight paper sessions, poster sessions, coffee/lunch breaks, panel, best paper awards, and closing remarks. Panel members are listed verbatim from the finalized schedule; afternoon times use 24h format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)