### PR TITLE
Match schedule wording to finalized source text

### DIFF
--- a/index.html
+++ b/index.html
@@ -329,7 +329,7 @@
               <div class="col-md-2"><time><center>Time: <br> 10:00-10:40 </time></div>
               <div class="col-md-10">
                 <h4>AdvML Rising Star Award Presentations</h4>
-                <p>(4 &times; 10 min)</p>
+                <p>(4&times;10 min)</p>
               </div>
             </div>
 
@@ -357,8 +357,8 @@
             <div class="row schedule-item">
               <div class="col-md-2"><time><center>Time: <br> 11:40-12:00 </time></div>
               <div class="col-md-10">
-                <h4>Oral / Spotlight Paper Presentations I</h4>
-                <p>(2 &times; 10 min)</p>
+                <h4>Oral/Spotlight Paper Presentations I</h4>
+                <p>(2&times;10 min)</p>
               </div>
             </div>
 
@@ -415,8 +415,8 @@
             <div class="row schedule-item">
               <div class="col-md-2"><time><center>Time: <br> 15:10-15:30 </time></div>
               <div class="col-md-10">
-                <h4>Oral / Spotlight Paper Presentations II</h4>
-                <p>(2 &times; 10 min)</p>
+                <h4>Oral/Spotlight Paper Presentations II</h4>
+                <p>(2&times;10 min)</p>
               </div>
             </div>
 
@@ -430,7 +430,7 @@
             <div class="row schedule-item">
               <div class="col-md-2"><time><center>Time: <br> 16:15-17:15 </time></div>
               <div class="col-md-10">
-                <h4>Panel Discussion</h4>
+                <h4>Panel</h4>
                 <p>Evtimov, Beirami, Cameron, Baracaldo, Bagdasarian</p>
               </div>
             </div>


### PR DESCRIPTION
Small wording corrections so the schedule matches the finalized source text exactly:

- "Panel Discussion" heading → "Panel"
- "Oral / Spotlight" → "Oral/Spotlight" (removed spaces around the slash)
- "(4 × 10 min)" / "(2 × 10 min)" → removed spaces around the multiplier

No structural/layout changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)