### PR TITLE
Adjust AM schedule: Rising Star talks 2×15 min, lunch starts 11:50

### DIFF
--- a/index.html
+++ b/index.html
@@ -326,15 +326,15 @@
             </div>
 
             <div class="row schedule-item">
-              <div class="col-md-2"><time><center>Time: <br> 10:00-10:40 </time></div>
+              <div class="col-md-2"><time><center>Time: <br> 10:00-10:30 </time></div>
               <div class="col-md-10">
                 <h4>AdvML Rising Star Award Presentations</h4>
-                <p>(4&times;10 min)</p>
+                <p>(2&times;15 min)</p>
               </div>
             </div>
 
             <div class="row schedule-item">
-              <div class="col-md-2"><time><center>Time: <br> 10:40-11:10 </time></div>
+              <div class="col-md-2"><time><center>Time: <br> 10:30-11:00 </time></div>
               <div class="col-md-10">
                 <h4>Invited Talk (CoTMA)</h4>
                 <h5><b>Evangelos Papalexakis</b></h5>
@@ -343,7 +343,7 @@
             </div>
 
             <div class="row schedule-item">
-              <div class="col-md-2"><time><center>Time: <br> 11:10-11:40 </time></div>
+              <div class="col-md-2"><time><center>Time: <br> 11:00-11:30 </time></div>
               <div class="col-md-10">
                 <div class="speaker">
                   <img src="img/speakers/RahulGupta.png" alt="Rahul Gupta">
@@ -355,7 +355,7 @@
             </div>
 
             <div class="row schedule-item">
-              <div class="col-md-2"><time><center>Time: <br> 11:40-12:00 </time></div>
+              <div class="col-md-2"><time><center>Time: <br> 11:30-11:50 </time></div>
               <div class="col-md-10">
                 <h4>Oral/Spotlight Paper Presentations I</h4>
                 <p>(2&times;10 min)</p>
@@ -363,7 +363,7 @@
             </div>
 
             <div class="row schedule-item">
-              <div class="col-md-2"><time><center>Time: <br> 12:00-13:00 </time></div>
+              <div class="col-md-2"><time><center>Time: <br> 11:50-13:00 </time></div>
               <div class="col-md-10">
                 <h4>&#127869; Lunch</h4>
               </div>


### PR DESCRIPTION
Per organizer request, to give more transition flexibility in the morning:

- **AdvML Rising Star Award Presentations**: 4×10 min (40 min) → **2×15 min (30 min)**, now 10:00–10:30
- **Invited Talk (Papalexakis)**: 10:40 → **10:30**
- **Invited Talk (Gupta)**: 11:10 → **11:00**
- **Oral/Spotlight Paper Presentations I**: 11:40 → **11:30** (ends 11:50)
- **Lunch**: 12:00–13:00 (60 min) → **11:50–13:00 (70 min)**

Afternoon (13:00 onward) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)