### PR TITLE
Update address bar hash on smooth-scroll nav clicks

### DIFF
--- a/js/main.js
+++ b/js/main.js
@@ -109,6 +109,11 @@ jQuery(document).ready(function( $ ) {
           scrollTop: target.offset().top - top_space
         }, 600, 'easeInOutExpo');
 
+        // Reflect the section in the address bar so the URL can be copied/pinned
+        if (history.pushState) {
+          history.pushState(null, null, this.hash);
+        }
+
         if ($(this).parents('.nav-menu').length) {
           $('.nav-menu .menu-active').removeClass('menu-active');
           $(this).closest('li').addClass('menu-active');


### PR DESCRIPTION
Clicking a nav link (e.g. "Schedule") smooth-scrolled to the section but left the address bar at the bare URL, because the `.scrollto` handler returns `false` (preventDefault), suppressing the browser's native hash update. As a result, copying the URL didn't deep-link to the section.

Adds `history.pushState(null, null, this.hash)` after the scroll animation so the URL reflects the target section (`#schedule`, `#speakers`, `#CallForPapers`, …) — making it copyable/pinnable — without re-triggering a jump the way `location.hash =` would.

🤖 Generated with [Claude Code](https://claude.com/claude-code)